### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.11.0",
     "react-native": "0.62.2",
-    "react-native-plaid-link-sdk": "4.0.0"
+    "react-native-plaid-link-sdk": "5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",


### PR DESCRIPTION
@luke-knol Hi Luke.  Android 2.1.2 is only compatible with 5+ of the RN sdk.  This fix updates `package.json` to `"react-native-plaid-link-sdk": "5.0.0"`  then you'll need to run `npm install` and finally run the app with `react-native run-android`

Sorry for the confusion, we'll update the docs